### PR TITLE
Potential fix for #12: topic presence notifications

### DIFF
--- a/src/components/Topic.vue
+++ b/src/components/Topic.vue
@@ -15,7 +15,7 @@
         </div>
 
         <div class="contact-right">
-          <div v-if="topic.online === true" class="contact-presence">
+          <div v-if="topicOnline" class="contact-presence">
               <span>&#183;</span>
           </div>
 
@@ -47,20 +47,13 @@ export default {
       return this.topic.touched;
     },
     topicOnline() {
-      return this.topic.online;
+      return store.state.client.tinodeClient.getTopic(this.topic.topic).online;
     }
   }
 };
 </script>
 
 <style lang="scss">
-// p {
-//   -webkit-user-select: text;
-//   -khtml-user-select: text;
-//   -moz-user-select: text;
-//   -o-user-select: text;
-//   user-select: text;
-// }
 .contact {
   display: flex;
   justify-content: center;

--- a/src/store/modules/client.js
+++ b/src/store/modules/client.js
@@ -89,36 +89,10 @@ export default {
 
           me.onPres = function(pres) {
             console.log("Received Presence msg:", pres);
-            let contact = store.getters.contacts.find(c => {
-              return c.topic == pres.src;
+            store.dispatch("updateTopicPresence", {
+              topicID: pres.src,
+              presence: pres.what == "on" ? true : false
             });
-            if (contact) {
-              if (pres.topic == "me") {
-                switch (pres.what) {
-                  case "on":
-                    store.dispatch("updateTopicPresence", {
-                      topicID: pres.src,
-                      presence: true
-                    });
-
-                    break;
-                  case "off":
-                    store.dispatch("updateTopicPresence", {
-                      topicID: pres.src,
-                      presence: false
-                    });
-                    break;
-
-                  case "msg":
-                    // presence message for a notification
-                    break;
-                }
-              }
-            } else {
-              console.log(
-                "Received a presence message from someone whom client is not subbed to"
-              );
-            }
           };
 
           fnd.onMeta = function(meta) {

--- a/src/store/modules/contacts.js
+++ b/src/store/modules/contacts.js
@@ -3,18 +3,20 @@ import axios from "axios";
 
 export function defaultState() {
   return {
-    contacts: [],
+    contacts: [{}],
     selectedTopicID: "",
+
+    // Add contact form drop down menu in ContactsListView.vue
     addContactForm: {
       searchQuery: "",
-      searchResults: [],
+      searchResults: [{}],
       isVisible: false
     }
   };
 }
 
 export default {
-  state: defaultState,
+  state: defaultState(),
 
   mutations: {
     searchForTopic(state, query) {
@@ -95,13 +97,8 @@ export default {
         payload.topicID,
         payload.presence
       );
-
-      let contact = state.contacts.find(c => {
-        return c.topic == payload.topicID;
-      });
-      if (contact) {
-        contact.online = payload.presence;
-      }
+      let topic = store.state.client.tinodeClient.getTopic(payload.topicID);
+      topic.online = payload.presence;
     },
     selectTopic(state, topicID) {
       console.log("Selecting topic", topicID);


### PR DESCRIPTION
Notify the client that a particular topic in their contacts list is online.

For groups, this should mean that at least one group member is online.