### PR TITLE
Fix message output with multiple new lines

### DIFF
--- a/src/components/Message.vue
+++ b/src/components/Message.vue
@@ -101,7 +101,7 @@ export default {
     padding-bottom: 8px;
     padding-left: 8px;
     background-color: rgba(0, 0, 0, 0.3);
-		// white-space: pre-wrap;
+		white-space: pre-wrap;
   }
   .profile-left {
     float: left;

--- a/src/components/Message.vue
+++ b/src/components/Message.vue
@@ -15,9 +15,7 @@
 					<div class="message-head">
 				    {{ fromFN }}
 				  </div>
-				  <div class="content">
-				    {{ content }}
-												<br/><small class="timestamp">  {{ tsFormatted }} </small>
+				  <div class="content">{{ content }}<br/><small class="timestamp">  {{ tsFormatted }} </small>
 				  </div>
 			</div>
 		</div>
@@ -103,6 +101,7 @@ export default {
     padding-bottom: 8px;
     padding-left: 8px;
     background-color: rgba(0, 0, 0, 0.3);
+		// white-space: pre-wrap;
   }
   .profile-left {
     float: left;

--- a/src/components/MessagesListView.vue
+++ b/src/components/MessagesListView.vue
@@ -30,13 +30,17 @@
       <div class="send-message">
         <div class="message-input">
           <div class="field has-addons">
-            <textarea rows="1" v-model="messageInput" class="textarea" placeholder="Type something..."></textarea>
+            <textarea rows="1" v-model="messageInput" class="textarea" placeholder="Type something..."
+              @keydown.enter.exact.prevent="sendMessage"
+              @keyup.enter.exact.prevent="sendMessage"
+              @keydown.enter.shift.exact="newline">
+            </textarea>
           </div>
         </div>
 
         <div class="send-button">
           <div class="control">
-            <a @click="sendMessage()" class="button is-info">
+            <a @click="sendMessage" class="button is-info">
               Send
             </a>
           </div>
@@ -91,10 +95,13 @@ export default {
   methods: {
     sendMessage() {
       if (this.messageInput) {
-        console.log("Storing message");
+        console.log("Storing message", this.messageInput );
         store.dispatch("publishMessage", this.messageInput);
         this.messageInput = "";
       }
+    },
+    newline() {
+      this.messageInput += '\n'
     }
   }
 };

--- a/src/store/modules/messages.js
+++ b/src/store/modules/messages.js
@@ -13,14 +13,14 @@ export default {
   mutations: {
     storeMessage(state, message) {
       let messagesCache = state.messagesCache.get(message.topic);
-      // if (typeof message.content == "object")  {
-      //   if (message.content.fmt[0].tp == "BR") {
-      //     var tempArr = Array.from(message.content.txt);
-      //     tempArr.splice(message.content.fmt[0].at, 1, '\n');
-      //     message.content = tempArr.join('');
-      //     console.log(message.content);
-      //   }
-      // }
+      if (typeof message.content == "object")  {
+        if (message.content.fmt[0].tp == "BR") {
+          var tempArr = Array.from(message.content.txt);
+          tempArr.splice(message.content.fmt[0].at, 1, '\n');
+          message.content = tempArr.join('');
+          console.log(message.content);
+        }
+      }
       if (!messagesCache) {
         // initialize new array of messages at map location state.messagesCache[topicID]
         console.log("storing message in new messagesCache:", message);

--- a/src/store/modules/messages.js
+++ b/src/store/modules/messages.js
@@ -13,7 +13,14 @@ export default {
   mutations: {
     storeMessage(state, message) {
       let messagesCache = state.messagesCache.get(message.topic);
-
+      // if (typeof message.content == "object")  {
+      //   if (message.content.fmt[0].tp == "BR") {
+      //     var tempArr = Array.from(message.content.txt);
+      //     tempArr.splice(message.content.fmt[0].at, 1, '\n');
+      //     message.content = tempArr.join('');
+      //     console.log(message.content);
+      //   }
+      // }
       if (!messagesCache) {
         // initialize new array of messages at map location state.messagesCache[topicID]
         console.log("storing message in new messagesCache:", message);


### PR DESCRIPTION
Fixes the format of a message being sent that contains multiple lines through catching a "BR" in the .tp of the .fmt array (messages.content.fmt[0].tp). Then uses splice and join to add a newline character at the line-break.